### PR TITLE
Repeat and flex field

### DIFF
--- a/config/api/public/home.php
+++ b/config/api/public/home.php
@@ -20,58 +20,15 @@ $page = cockpit('singletons')->getData('Home', [
 // target gallery
 $gallery = $page['Gallery'];
 
-
-$blocks = $page['Blocks'];
-
-
-/**
- * Prepare block builder
- * @param array $pBlocks
- * @return array
- */
-function prepareBlockBuilder(array $pBlocks) :array
-{
-    // format block array
-    $formatBlocks = [];
-
-    // for each blocks
-    foreach ($pBlocks as $block)
-    {
-        // if field type name is "gallery"
-        if( $block['field']['type'] === "gallery")
-        {
-            // push in formatBlocks GalleryBlock => value
-            $formatBlocks["GalleryBlock"] = prepareGalleryField($block['value']);
-        }
-        // if field type name is "gallery"
-        if( $block['field']['type'] === "markdown")
-        {
-            // FIXME - la 2eme fois que l'on pass sur la clef, on écrase sa valeur
-            // push in formatBlocks MarkdownBlock => value
-            $formatBlocks["MarkdownBlock"] = $block['value'];
-        }
-    }
-
-    // return this format blocks array
-    return $formatBlocks;
-}
-
-
 return [
-
-
-    "blocks" => prepareBlockBuilder($page['Blocks']),
-
-    // page title
-   # "title" => $page["Title"],
-
-    // return only 1st element of the gallery
-   # "cover" => prepareGalleryField($page["Cover"])[0],
-
+   // page title
+    "title" => $page["Title"],
+    // Main Cover return only 1st element of the gallery
+    "cover" => prepareGalleryField($page["Cover"])[0],
     // gallery
-   # "gallery" => prepareGalleryField($page["Gallery"]),
-
-
+    "gallery" => prepareGalleryField($page["Gallery"]),
+    // Blocks
+    "blocks" => prepareBlockBuilder($page['Blocks']),
     //"_" => $page
 
 ];

--- a/config/prepare/prepare.php
+++ b/config/prepare/prepare.php
@@ -1,3 +1,4 @@
 <?php
 
 require_once __DIR__ . '/prepareGalleryField.php';
+require_once __DIR__ . '/prepareBLockBuilder.php';

--- a/config/prepare/prepareBLockBuilder.php
+++ b/config/prepare/prepareBLockBuilder.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Prepare block builder
+ * @param array $pBlocks
+ * @return array
+ */
+function prepareBlockBuilder (array $pBlocks) :array
+{
+    // format block array
+    $formatBlocks = [];
+
+    // for each blocks
+    foreach ($pBlocks as $block)
+    {
+
+        // Define here bocls informations
+        $prepareBlocks = [
+            "GalleryBlock"=> [
+                "fieldName" => "gallery",
+                "prepare" => prepareGalleryField($block['value'])
+            ],
+            "MarkdownBlock"=> [
+                "fieldName" => "markdown",
+                "prepare" => $block['value']
+            ],
+        ];
+
+        // map each blocks
+        foreach ($prepareBlocks as $key => $value)
+        {
+            // if field type name is "gallery"
+            if( $block['field']['type'] === $value['fieldName'])
+            {
+                // push in formatBlocks the final formated array return by the API
+                $formatBlocks[] = [
+                    "type" => $key,
+                    "blockData" => $value['prepare']
+                ];
+            }
+        }
+    }
+
+    // return format blocks array
+    return $formatBlocks;
+}

--- a/config/prepare/prepareGalleryField.php
+++ b/config/prepare/prepareGalleryField.php
@@ -20,7 +20,7 @@ function prepareGalleryField ($pGallery) :array
         // create format gallery array
         $formatGallery = [];
 
-        // map of each  gallery image
+        // map each images
         foreach ($pGallery as $item)
         {
             // push format responsive image result in array
@@ -29,6 +29,5 @@ function prepareGalleryField ($pGallery) :array
 
         // return the formated array
         return $formatGallery;
-        //return $pGallery;
     }
 }

--- a/storage/singleton/Home.singleton.php
+++ b/storage/singleton/Home.singleton.php
@@ -134,7 +134,7 @@
   'template' => '',
   'data' => NULL,
   '_created' => 1575650950,
-  '_modified' => 1575674132,
+  '_modified' => 1575714519,
   'description' => '',
   'acl' => 
   array (
@@ -148,5 +148,5 @@
     ),
   ),
   'color' => '#48CFAD',
-  'icon' => 'globe.svg',
+  'icon' => 'post.svg',
 );


### PR DESCRIPTION
fixes #2 

Block builder field example:

```json
{
  "fields": [
    {
      "type": "markdown",
      "label": "Text Block"
    },
    {
      "type": "gallery",
      "label": "Image Block"
    },
    {
      "type": "repeater",
      "label": "item",
      "options": {
        "fields": [
          {
            "type": "text",
            "label": "Text component"
          }
        ]
      }
    }
  ]
}
```