### PR TITLE
Prepare markdown field

### DIFF
--- a/config/api/public/home.php
+++ b/config/api/public/home.php
@@ -2,7 +2,6 @@
 <?php
 /**
  * Home SingleTons
- *
  * @infos https://discourse.getcockpit.com/t/how-to-create-custom-api-endpoints/202/4
  * @access http://localhost/cockpit-base/trunk/api/public/home
  */
@@ -17,12 +16,11 @@ $page = cockpit('singletons')->getData('Home', [
     'lang' => $lang
 ]);
 
-// target gallery
-$gallery = $page['Gallery'];
-
 return [
    // page title
     "title" => $page["Title"],
+    // desc
+    "description" => prepareMarkdownField($page["Description"]),
     // Main Cover return only 1st element of the gallery
     "cover" => prepareGalleryField($page["Cover"])[0],
     // gallery

--- a/config/prepare/prepare.php
+++ b/config/prepare/prepare.php
@@ -2,3 +2,4 @@
 
 require_once __DIR__ . '/prepareGalleryField.php';
 require_once __DIR__ . '/prepareBLockBuilder.php';
+require_once __DIR__ . '/prepareMarkdownField.php';

--- a/config/prepare/prepareBLockBuilder.php
+++ b/config/prepare/prepareBLockBuilder.php
@@ -22,7 +22,7 @@ function prepareBlockBuilder (array $pBlocks) :array
             ],
             "MarkdownBlock"=> [
                 "fieldName" => "markdown",
-                "prepare" => $block['value']
+                "prepare" => prepareMarkdownField($block['value'])
             ],
         ];
 

--- a/config/prepare/prepareMarkdownField.php
+++ b/config/prepare/prepareMarkdownField.php
@@ -1,0 +1,18 @@
+
+<?php
+
+/**
+ * Prepare Markown Field
+ * Parse with Parsdown
+ * @doc: https://parsedown.org/
+ * @param $pMarkdownData
+ * @return string
+ */
+function prepareMarkdownField ($pMarkdownData) :string
+{
+    // parse field
+    $parseMarkdown = Parsedown::instance()->text($pMarkdownData);
+
+    // return result
+    return $parseMarkdown;
+}


### PR DESCRIPTION
fixes #16 

# Achievement

Create a simple`prepareMarkdownField` function using parser [Parsdown](https://parsedown.org/).

# Usage

```php
prepareMarkdownField($text);
```
