### PR TITLE
Test translate fields

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -15,8 +15,9 @@ return [
     'languages' => [
         # setting a default language is optional
         'default' => 'English',
-
+        // french
         'fr' => 'French',
+        'de' => 'German',
     ],
 
     # define additional groups

--- a/storage/singleton/Home.singleton.php
+++ b/storage/singleton/Home.singleton.php
@@ -13,7 +13,7 @@
       'default' => '',
       'info' => '',
       'group' => '',
-      'localize' => false,
+      'localize' => true,
       'options' => 
       array (
       ),
@@ -71,13 +71,13 @@
     ),
     3 => 
     array (
-      'name' => 'Gallery',
+      'name' => 'Description',
       'label' => '',
-      'type' => 'gallery',
+      'type' => 'markdown',
       'default' => '',
       'info' => '',
       'group' => '',
-      'localize' => false,
+      'localize' => true,
       'options' => 
       array (
       ),
@@ -89,9 +89,9 @@
     ),
     4 => 
     array (
-      'name' => 'Description',
+      'name' => 'Gallery',
       'label' => '',
-      'type' => 'markdown',
+      'type' => 'gallery',
       'default' => '',
       'info' => '',
       'group' => '',
@@ -113,7 +113,7 @@
       'default' => '',
       'info' => '',
       'group' => '',
-      'localize' => false,
+      'localize' => true,
       'options' => 
       array (
         'fields' => 
@@ -156,7 +156,7 @@
   'template' => '',
   'data' => NULL,
   '_created' => 1575650950,
-  '_modified' => 1575733293,
+  '_modified' => 1575738296,
   'description' => '',
   'acl' => 
   array (


### PR DESCRIPTION
fixes #1 

# Achievement 

- Eable to add and remove new locale available for each user entries. 
- Request specific language endpoint with param url
- If  default language is set, and we don't "localize" a field, the field with default language will be return.

# Usage

1. In `config/config.php`, set each language needed : 

```php
    'languages' => [
        'default' => 'English',
        'fr' => 'French',
        'de' => 'German',
    ]
```
1. Edit a field in collection post or singleton (ex: Tilte) and active "Localize" option on the bottom.
1. Edit the field content like an editor user and toggle the language on the right.
1. Request the API with `?lang=fr`and the end.

Note: it's possible to request every time with `?lang={local}` param. Even if `en` local is not set, the API will return the default one.

That's it 👍 



